### PR TITLE
Log focused file and file browser paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const openFolder = (folder: string) => {
       labShell.activateById(browser.id);
       browserModel.cd(folder);
-    }
+    };
     const openPath = (path: string) => docManager.openOrReveal(path);
     const automationBody = new AutomationBody(commands, openFolder, openPath);
     const refresh = () =>
       automationBody.updateModel({ folder: '/' + browserModel.path });
     browserModel.pathChanged.connect(refresh);
     labShell.layoutModified.connect(refresh);
+    registerFocusPathLogger(labShell, docManager, browser);
 
     shell.add(automationBody, 'right', { rank: 1000 });
 
@@ -62,6 +63,85 @@ const plugin: JupyterFrontEndPlugin<void> = {
       restorer.add(automationBody, automationBody.id);
     }
   }
+};
+
+interface IFileBrowserLike {
+  model: {
+    path: string;
+  };
+  node: HTMLElement;
+}
+
+const normalizeBrowserFolder = (path: string): string => {
+  return path ? `/${path}` : '/';
+};
+
+const getWidgetPath = (
+  docManager: IDocumentManager,
+  widget: ILabShell['currentWidget']
+): string | null => {
+  if (!widget) {
+    return null;
+  }
+  return docManager.contextForWidget(widget)?.path || null;
+};
+
+const isNode = (target: EventTarget | null): target is Node => {
+  return target instanceof Node;
+};
+
+const registerFocusPathLogger = (
+  labShell: ILabShell,
+  docManager: IDocumentManager,
+  browser: IFileBrowserLike
+): void => {
+  let lastLoggedPath = '';
+  let lastLoggedAt = 0;
+
+  const logPath = (path: string | null): void => {
+    if (!path) {
+      return;
+    }
+    const now = Date.now();
+    if (path === lastLoggedPath && now - lastLoggedAt < 50) {
+      return;
+    }
+    lastLoggedPath = path;
+    lastLoggedAt = now;
+    console.log(path);
+  };
+
+  const logBrowserFolder = (): void => {
+    logPath(normalizeBrowserFolder(browser.model.path));
+  };
+
+  const logCurrentDocument = (): void => {
+    logPath(getWidgetPath(docManager, labShell.currentWidget));
+  };
+
+  const scheduleCurrentDocumentLog = (): void => {
+    window.requestAnimationFrame(logCurrentDocument);
+  };
+
+  const handleFocusOrClick = (event: Event): void => {
+    if (!isNode(event.target)) {
+      return;
+    }
+    if (browser.node.contains(event.target)) {
+      logBrowserFolder();
+      return;
+    }
+    if (!labShell.currentWidget?.node.contains(event.target)) {
+      return;
+    }
+    scheduleCurrentDocumentLog();
+  };
+
+  labShell.currentPathChanged.connect((_, args) => {
+    logPath(args.newValue);
+  });
+  document.addEventListener('focusin', handleFocusOrClick, true);
+  document.addEventListener('click', handleFocusOrClick, true);
 };
 
 export default plugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
       automationBody.updateModel({ folder: '/' + browserModel.path });
     browserModel.pathChanged.connect(refresh);
     labShell.layoutModified.connect(refresh);
-    registerFocusPathLogger(labShell, docManager, browser);
+    const disposeFocusPathLogger = registerFocusPathLogger(
+      labShell,
+      docManager,
+      browser
+    );
+    automationBody.disposed.connect(disposeFocusPathLogger);
 
     shell.add(automationBody, 'right', { rank: 1000 });
 
@@ -95,7 +100,7 @@ const registerFocusPathLogger = (
   labShell: ILabShell,
   docManager: IDocumentManager,
   browser: IFileBrowserLike
-): void => {
+): (() => void) => {
   let lastLoggedPath = '';
   let lastLoggedAt = 0;
 
@@ -138,11 +143,22 @@ const registerFocusPathLogger = (
     scheduleCurrentDocumentLog();
   };
 
-  labShell.currentPathChanged.connect((_, args) => {
+  const handleCurrentPathChanged = (
+    _: ILabShell,
+    args: ILabShell.ICurrentPathChangedArgs
+  ): void => {
     logPath(normalizePath(args.newValue));
-  });
+  };
+
+  labShell.currentPathChanged.connect(handleCurrentPathChanged);
   document.addEventListener('focusin', handleFocusOrClick, true);
   document.addEventListener('click', handleFocusOrClick, true);
+
+  return (): void => {
+    labShell.currentPathChanged.disconnect(handleCurrentPathChanged);
+    document.removeEventListener('focusin', handleFocusOrClick, true);
+    document.removeEventListener('click', handleFocusOrClick, true);
+  };
 };
 
 export default plugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ interface IFileBrowserLike {
   node: HTMLElement;
 }
 
-const normalizeBrowserFolder = (path: string): string => {
-  return path ? `/${path}` : '/';
+const normalizePath = (path: string): string => {
+  return path ? `/${path.replace(/^\/+/, '')}` : '/';
 };
 
 const getWidgetPath = (
@@ -83,7 +83,8 @@ const getWidgetPath = (
   if (!widget) {
     return null;
   }
-  return docManager.contextForWidget(widget)?.path || null;
+  const path = docManager.contextForWidget(widget)?.path;
+  return path ? normalizePath(path) : null;
 };
 
 const isNode = (target: EventTarget | null): target is Node => {
@@ -112,7 +113,7 @@ const registerFocusPathLogger = (
   };
 
   const logBrowserFolder = (): void => {
-    logPath(normalizeBrowserFolder(browser.model.path));
+    logPath(normalizePath(browser.model.path));
   };
 
   const logCurrentDocument = (): void => {
@@ -138,7 +139,7 @@ const registerFocusPathLogger = (
   };
 
   labShell.currentPathChanged.connect((_, args) => {
-    logPath(args.newValue);
+    logPath(normalizePath(args.newValue));
   });
   document.addEventListener('focusin', handleFocusOrClick, true);
   document.addEventListener('click', handleFocusOrClick, true);


### PR DESCRIPTION
/claim #39

Fixes #39.

## Summary
- Log the active document path when JupyterLab switches the current document path.
- Log the active document path when the focused/clicked target is inside the current document widget.
- Log the current file browser folder when the focused/clicked target is inside the file browser.
- Dedupe immediate focus/click bursts so the console does not print the same path repeatedly.
- Clean up the current-path signal handler and document focus/click listeners when the automation widget is disposed.

## Validation
- `npm run build:lib` -> passed
- `npx prettier --check src/index.ts` -> passed
- `npx eslint src/index.ts --quiet` -> passed
- `git diff --check` -> passed

Not run: full `npm run build`, because this local Windows environment does not have `jlpm` available for the repo's labextension build script.