### PR TITLE
Log focused JupyterLab paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ import { AutomationBody } from './body';
 const normalizeJupyterPath = (path = ''): string =>
   '/' + path.replace(/^\/+/, '');
 
+const DOCUMENT_AREA_SELECTOR =
+  '#jp-main-dock-panel, .jp-MainAreaWidget, .jp-DocumentWidget';
+const LOG_DEDUPE_WINDOW_MS = 100;
+
 const targetIsInside = (
   target: EventTarget | null,
   selector: string
@@ -56,13 +60,25 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     shell.add(automationBody, 'right', { rank: 1000 });
 
-    let lastLoggedPath: string | null = null;
+    let lastLoggedPathInBurst: string | null = null;
+    let clearLastLoggedPathTimeout: number | null = null;
+    const clearLastLoggedPathInBurst = () => {
+      lastLoggedPathInBurst = null;
+      clearLastLoggedPathTimeout = null;
+    };
     const logPath = (path: string) => {
       const normalizedPath = normalizeJupyterPath(path);
-      if (normalizedPath === lastLoggedPath) {
+      if (normalizedPath === lastLoggedPathInBurst) {
         return;
       }
-      lastLoggedPath = normalizedPath;
+      lastLoggedPathInBurst = normalizedPath;
+      if (clearLastLoggedPathTimeout !== null) {
+        window.clearTimeout(clearLastLoggedPathTimeout);
+      }
+      clearLastLoggedPathTimeout = window.setTimeout(
+        clearLastLoggedPathInBurst,
+        LOG_DEDUPE_WINDOW_MS
+      );
       console.log(normalizedPath);
     };
     const logActiveDocumentPath = () => {
@@ -79,13 +95,18 @@ const plugin: JupyterFrontEndPlugin<void> = {
         logPath(browserModel.path);
         return;
       }
-      window.setTimeout(logActiveDocumentPath, 0);
+      if (targetIsInside(event.target, DOCUMENT_AREA_SELECTOR)) {
+        window.setTimeout(logActiveDocumentPath, 0);
+      }
     };
     document.addEventListener('focusin', logFocusedPath, true);
     document.addEventListener('click', logFocusedPath, true);
     automationBody.disposed.connect(() => {
       document.removeEventListener('focusin', logFocusedPath, true);
       document.removeEventListener('click', logFocusedPath, true);
+      if (clearLastLoggedPathTimeout !== null) {
+        window.clearTimeout(clearLastLoggedPathTimeout);
+      }
     });
 
     /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,17 @@ import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
 import { AutomationBody } from './body';
 
+const normalizeJupyterPath = (path = ''): string =>
+  '/' + path.replace(/^\/+/, '');
+
+const targetIsInside = (
+  target: EventTarget | null,
+  selector: string
+): boolean => {
+  const element = target instanceof Element ? target : null;
+  return element?.closest(selector) !== null;
+};
+
 /**
  * Initialization data for the jupyterlab-crosscompute extension.
  */
@@ -35,7 +46,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const openFolder = (folder: string) => {
       labShell.activateById(browser.id);
       browserModel.cd(folder);
-    }
+    };
     const openPath = (path: string) => docManager.openOrReveal(path);
     const automationBody = new AutomationBody(commands, openFolder, openPath);
     const refresh = () =>
@@ -44,6 +55,38 @@ const plugin: JupyterFrontEndPlugin<void> = {
     labShell.layoutModified.connect(refresh);
 
     shell.add(automationBody, 'right', { rank: 1000 });
+
+    let lastLoggedPath: string | null = null;
+    const logPath = (path: string) => {
+      const normalizedPath = normalizeJupyterPath(path);
+      if (normalizedPath === lastLoggedPath) {
+        return;
+      }
+      lastLoggedPath = normalizedPath;
+      console.log(normalizedPath);
+    };
+    const logActiveDocumentPath = () => {
+      const currentWidget = labShell.currentWidget;
+      const context = currentWidget
+        ? docManager.contextForWidget(currentWidget)
+        : null;
+      if (context?.path) {
+        logPath(context.path);
+      }
+    };
+    const logFocusedPath = (event: Event) => {
+      if (targetIsInside(event.target, '.jp-FileBrowser')) {
+        logPath(browserModel.path);
+        return;
+      }
+      window.setTimeout(logActiveDocumentPath, 0);
+    };
+    document.addEventListener('focusin', logFocusedPath, true);
+    document.addEventListener('click', logFocusedPath, true);
+    automationBody.disposed.connect(() => {
+      document.removeEventListener('focusin', logFocusedPath, true);
+      document.removeEventListener('click', logFocusedPath, true);
+    });
 
     /*
     if (settingRegistry) {


### PR DESCRIPTION
## Summary
- Adds focus/click listeners that log the current file-browser folder when the file browser receives interaction.
- Logs the active document path when focus/click returns to an opened document in the shell.
- Normalizes console output to slash-prefixed paths and dedupes paired focus/click events.

## Validation
- `npm run build:lib`
- `npx prettier --check src/index.ts`
- `npx eslint src/index.ts --quiet`
- `git diff --check HEAD~1..HEAD`

Closes #39

/claim #39